### PR TITLE
update to php 8.3. for 6.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# Start from the official PHP 8.2 image with Apache
-FROM php:8.2-apache
+# Start from the official PHP 8.3 image with Apache
+FROM php:8.3-apache
 
 # Install system dependencies, Node.js, Composer, and Cypress dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Pull Request for Issue #45719 .

### Summary of Changes
the minimum reuired version for joomla 6.0 is 8.3


### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
